### PR TITLE
Implement basic editing and stats improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-parcelize'
     id 'dagger.hilt.android.plugin'
     id 'com.google.devtools.ksp'
 }

--- a/app/src/main/java/com/taskmaster/data/entity/Task.kt
+++ b/app/src/main/java/com/taskmaster/data/entity/Task.kt
@@ -1,9 +1,12 @@
 package com.taskmaster.data.entity
 
+import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import kotlinx.parcelize.Parcelize
 import java.util.Date
 
+@Parcelize
 @Entity(tableName = "tasks")
 data class Task(
     @PrimaryKey(autoGenerate = true)
@@ -18,4 +21,4 @@ data class Task(
     val completedAt: Date? = null,
     val xpReward: Int = 0,
     val parentTaskId: Long? = null
-)
+) : Parcelable

--- a/app/src/main/java/com/taskmaster/ui/adapter/CalendarAdapter.kt
+++ b/app/src/main/java/com/taskmaster/ui/adapter/CalendarAdapter.kt
@@ -5,12 +5,13 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.taskmaster.R
 import com.taskmaster.databinding.ItemCalendarDayBinding
 import java.text.SimpleDateFormat
 import java.util.*
 
 sealed class CalendarDay {
-    data class DateDay(val date: Date) : CalendarDay()
+    data class DateDay(val date: Date, val progress: Float) : CalendarDay()
     object EmptyDay : CalendarDay()
 }
 
@@ -43,6 +44,12 @@ class CalendarAdapter(
                     binding.textDay.text = dateFormat.format(calendarDay.date)
                     binding.root.setOnClickListener { onDateClick(calendarDay.date) }
                     binding.root.alpha = 1.0f
+                    val colorRes = when {
+                        calendarDay.progress >= 1f -> R.color.success
+                        calendarDay.progress > 0f -> R.color.warning
+                        else -> android.R.color.transparent
+                    }
+                    binding.root.setBackgroundColor(binding.root.context.getColor(colorRes))
                 }
                 is CalendarDay.EmptyDay -> {
                     binding.textDay.text = ""

--- a/app/src/main/java/com/taskmaster/ui/adapter/TaskAdapter.kt
+++ b/app/src/main/java/com/taskmaster/ui/adapter/TaskAdapter.kt
@@ -10,6 +10,7 @@ import com.taskmaster.R
 import com.taskmaster.data.entity.Task
 import com.taskmaster.databinding.ItemTaskBinding
 import com.taskmaster.utils.PriorityUtils
+import java.util.Date
 
 class TaskAdapter(
     private val onTaskClick: (Task) -> Unit,
@@ -49,10 +50,18 @@ class TaskAdapter(
                 priorityIndicator.setBackgroundColor(colorInt)
 
                 // Set click listeners
-                root.setOnClickListener { onTaskClick(task) }
+                root.setOnLongClickListener { onTaskClick(task); true }
                 buttonComplete.setOnClickListener { onCompleteClick(task) }
                 buttonPostpone.setOnClickListener { onPostponeClick(task) }
                 buttonDelete.setOnClickListener { onDeleteClick(task) }
+
+                if (task.isCompleted) {
+                    root.strokeColor = ContextCompat.getColor(root.context, R.color.success)
+                } else if (task.dueDate != null && task.dueDate.before(Date())) {
+                    root.strokeColor = ContextCompat.getColor(root.context, R.color.warning)
+                } else {
+                    root.strokeColor = ContextCompat.getColor(root.context, android.R.color.transparent)
+                }
             }
         }
     }

--- a/app/src/main/java/com/taskmaster/ui/dialogs/EditProfileDialogFragment.kt
+++ b/app/src/main/java/com/taskmaster/ui/dialogs/EditProfileDialogFragment.kt
@@ -1,0 +1,61 @@
+package com.taskmaster.ui.dialogs
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import com.taskmaster.databinding.DialogEditProfileBinding
+import com.taskmaster.ui.viewmodel.ProfileViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class EditProfileDialogFragment : DialogFragment() {
+
+    private var _binding: DialogEditProfileBinding? = null
+    private val binding get() = _binding!!
+
+    private val profileViewModel: ProfileViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogEditProfileBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        profileViewModel.currentUser.observe(this) { user ->
+            user?.let {
+                binding.editTextName.setText(it.name)
+                binding.editTextCity.setText(it.city)
+            }
+        }
+
+        binding.buttonSave.setOnClickListener { saveProfile() }
+        binding.buttonCancel.setOnClickListener { dismiss() }
+    }
+
+    private fun saveProfile() {
+        val name = binding.editTextName.text.toString().trim()
+        val city = binding.editTextCity.text.toString().trim()
+        profileViewModel.currentUser.value?.let { user ->
+            profileViewModel.updateProfile(user.copy(name = name, city = city))
+        }
+        dismiss()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        fun newInstance() = EditProfileDialogFragment()
+    }
+}

--- a/app/src/main/java/com/taskmaster/ui/fragments/CalendarFragment.kt
+++ b/app/src/main/java/com/taskmaster/ui/fragments/CalendarFragment.kt
@@ -68,20 +68,22 @@ class CalendarFragment : Fragment() {
         val daysInMonth = calendar.getActualMaximum(Calendar.DAY_OF_MONTH)
         val firstDayOfWeek = calendar.get(Calendar.DAY_OF_WEEK) - 1
 
-        val days = mutableListOf<CalendarDay>()
+        lifecycleScope.launch {
+            val days = mutableListOf<CalendarDay>()
 
-        // Add empty days for the first week
-        for (i in 0 until firstDayOfWeek) {
-            days.add(CalendarDay.EmptyDay)
+            for (i in 0 until firstDayOfWeek) {
+                days.add(CalendarDay.EmptyDay)
+            }
+
+            for (day in 1..daysInMonth) {
+                calendar.set(Calendar.DAY_OF_MONTH, day)
+                val date = Date(calendar.timeInMillis)
+                val progress = taskViewModel.getDayProgress(date)
+                days.add(CalendarDay.DateDay(date, progress))
+            }
+
+            calendarAdapter.submitList(days)
         }
-
-        // Add days of the month
-        for (day in 1..daysInMonth) {
-            calendar.set(Calendar.DAY_OF_MONTH, day)
-            days.add(CalendarDay.DateDay(Date(calendar.timeInMillis)))
-        }
-
-        calendarAdapter.submitList(days)
     }
 
     private fun showTasksForDate(date: Date) {

--- a/app/src/main/java/com/taskmaster/ui/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/taskmaster/ui/fragments/ProfileFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.taskmaster.databinding.FragmentProfileBinding
+import com.taskmaster.ui.dialogs.EditProfileDialogFragment
 import com.taskmaster.ui.viewmodel.ProfileViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -30,6 +31,7 @@ class ProfileFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
+        binding.buttonEditProfile.setOnClickListener { showEditDialog() }
     }
 
     private fun setupObservers() {
@@ -47,6 +49,11 @@ class ProfileFragment : Fragment() {
             textXp.text = "${user.totalXp} XP"
             textStreak.text = "${user.currentStreak} дней"
         }
+    }
+
+    private fun showEditDialog() {
+        val dialog = EditProfileDialogFragment.newInstance()
+        dialog.show(parentFragmentManager, "EditProfileDialog")
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/taskmaster/ui/fragments/StatisticsFragment.kt
+++ b/app/src/main/java/com/taskmaster/ui/fragments/StatisticsFragment.kt
@@ -9,6 +9,8 @@ import androidx.fragment.app.viewModels
 import com.taskmaster.databinding.FragmentStatisticsBinding
 import com.taskmaster.ui.viewmodel.TaskViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.Calendar
+import java.util.Date
 
 @AndroidEntryPoint
 class StatisticsFragment : Fragment() {
@@ -43,10 +45,20 @@ class StatisticsFragment : Fragment() {
         val totalTasks = tasks.size
         val completionRate = if (totalTasks > 0) (completedTasks * 100) / totalTasks else 0
 
+        val calendar = Calendar.getInstance()
+        val end = calendar.time
+        calendar.add(Calendar.DAY_OF_YEAR, -7)
+        val start = calendar.time
+        val tasksLastWeek = tasks.filter { task ->
+            task.dueDate?.let { it.after(start) && it.before(end) } == true
+        }
+        val avg = if (tasksLastWeek.isNotEmpty()) tasksLastWeek.size / 7f else 0f
+
         binding.apply {
             textCompletedTasks.text = completedTasks.toString()
             textTotalTasks.text = totalTasks.toString()
             textCompletionRate.text = "$completionRate%"
+            textAverageTasks.text = String.format("%.1f", avg)
         }
     }
 

--- a/app/src/main/java/com/taskmaster/ui/fragments/TodayFragment.kt
+++ b/app/src/main/java/com/taskmaster/ui/fragments/TodayFragment.kt
@@ -44,7 +44,9 @@ class TodayFragment : Fragment() {
 
     private fun setupRecyclerView() {
         taskAdapter = TaskAdapter(
-            onTaskClick = { _ -> /* Handle task click */ },
+            onTaskClick = { task ->
+                showEditTaskDialog(task)
+            },
             onCompleteClick = { task ->
                 taskViewModel.completeTask(task)
                 showCompletionFeedback(task)
@@ -100,12 +102,12 @@ class TodayFragment : Fragment() {
 
     private fun setupClickListeners() {
         binding.fabAddTask.setOnClickListener {
-            showCreateTaskDialog()
+            showCreateTaskDialog(null)
         }
     }
 
-    private fun showCreateTaskDialog() {
-        val dialog = CreateTaskDialogFragment.newInstance()
+    private fun showCreateTaskDialog(task: com.taskmaster.data.entity.Task?) {
+        val dialog = CreateTaskDialogFragment.newInstance(task)
         dialog.show(parentFragmentManager, "CreateTaskDialog")
     }
 
@@ -125,12 +127,22 @@ class TodayFragment : Fragment() {
             .show()
     }
 
+    private fun showEditTaskDialog(task: com.taskmaster.data.entity.Task) {
+        showCreateTaskDialog(task)
+    }
+
     private fun showDeleteConfirmation(task: com.taskmaster.data.entity.Task) {
         AlertDialog.Builder(requireContext())
             .setTitle("Удалить задачу?")
-            .setMessage("Это действие нельзя отменить")
+            .setMessage("Это действие можно отменить в течение 15 секунд")
             .setPositiveButton("Удалить") { _, _ ->
                 taskViewModel.deleteTask(task)
+                Snackbar.make(binding.root, "Задача удалена", Snackbar.LENGTH_LONG)
+                    .setAction("Отмена") {
+                        taskViewModel.restoreTask(task)
+                    }
+                    .setDuration(15000)
+                    .show()
             }
             .setNegativeButton("Отмена", null)
             .show()

--- a/app/src/main/java/com/taskmaster/ui/viewmodel/TaskViewModel.kt
+++ b/app/src/main/java/com/taskmaster/ui/viewmodel/TaskViewModel.kt
@@ -107,6 +107,28 @@ class TaskViewModel @Inject constructor(
         }
     }
 
+    fun updateTask(task: Task) {
+        viewModelScope.launch {
+            try {
+                taskRepository.updateTask(task)
+                loadTodayData()
+            } catch (e: Exception) {
+                _errorMessage.value = "Ошибка обновления задачи: ${e.message}"
+            }
+        }
+    }
+
+    fun restoreTask(task: Task) {
+        viewModelScope.launch {
+            try {
+                taskRepository.insertTask(task.copy(id = 0))
+                loadTodayData()
+            } catch (e: Exception) {
+                _errorMessage.value = "Ошибка восстановления задачи: ${e.message}"
+            }
+        }
+    }
+
     fun deleteTask(task: Task) {
         viewModelScope.launch {
             try {

--- a/app/src/main/res/layout/dialog_edit_profile.xml
+++ b/app/src/main/res/layout/dialog_edit_profile.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:hint="Имя">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/edit_text_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:hint="Город">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/edit_text_city"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end">
+
+        <Button
+            android:id="@+id/button_cancel"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="Отмена" />
+
+        <Button
+            android:id="@+id/button_save"
+            style="@style/Widget.Material3.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Сохранить" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -65,6 +65,14 @@
 
         </com.google.android.material.card.MaterialCardView>
 
+        <Button
+            android:id="@+id/button_edit_profile"
+            style="@style/Widget.Material3.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:text="Редактировать" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_statistics.xml
+++ b/app/src/main/res/layout/fragment_statistics.xml
@@ -118,6 +118,38 @@
 
         </com.google.android.material.card.MaterialCardView>
 
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Среднее задач в день (7д)"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/text_average_tasks"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    tools:text="2.0" />
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
     </LinearLayout>
 
 </ScrollView>


### PR DESCRIPTION
## Summary
- enable Parcelable on Task entity
- allow editing tasks via dialog
- support undo delete
- color calendar days by progress
- add profile editing dialog
- show average tasks per day in statistics

## Testing
- `./gradlew test` *(fails: unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686a68beba448328977784a25b762949