### PR TITLE
Fix tools namespace and layout

### DIFF
--- a/app/src/main/res/layout/dialog_tasks_by_date.xml
+++ b/app/src/main/res/layout/dialog_tasks_by_date.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
 
     android:layout_width="match_parent"
     android:layout_height="wrap_content">

--- a/app/src/main/res/layout/item_sphere_stat.xml
+++ b/app/src/main/res/layout/item_sphere_stat.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-
     xmlns:tools="http://schemas.android.com/tools"
-
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"


### PR DESCRIPTION
## Summary
- fix missing `tools` namespace in the date dialog layout
- tidy up the `item_sphere_stat` layout root

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a81e8d1848328b948193d45a62430