### PR TITLE
Fix adapter callbacks and imports

### DIFF
--- a/app/src/main/java/com/taskmaster/ui/dialogs/CreateTaskDialogFragment.kt
+++ b/app/src/main/java/com/taskmaster/ui/dialogs/CreateTaskDialogFragment.kt
@@ -273,11 +273,10 @@ class CreateTaskDialogFragment : DialogFragment() {
                 } else {
                     if (isComplexTask) {
 
-                        val subtasks = subtaskFields.map { it.text.toString().trim() }.filter { it.isNotEmpty() }
+                        val subtasks = subtaskFields
+                            .map { it.text.toString().trim() }
+                            .filter { it.isNotEmpty() }
                         createComplexTask(title, description, priority, sphereId, subtasks)
-
-                        val subtasksText = binding.editTextSubtasks.text.toString().trim()
-                        createComplexTask(title, description, priority, sphereId, subtasksText)
 
 
                     } else {

--- a/app/src/main/java/com/taskmaster/ui/dialogs/DateTasksDialogFragment.kt
+++ b/app/src/main/java/com/taskmaster/ui/dialogs/DateTasksDialogFragment.kt
@@ -39,9 +39,9 @@ class DateTasksDialogFragment : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         adapter = TaskAdapter(
             onTaskClick = { task -> },
-            onCompleteClick = { taskViewModel.completeTask(task) },
-            onPostponeClick = { taskViewModel.postponeTask(task) },
-            onDeleteClick = { taskViewModel.deleteTask(task) }
+            onCompleteClick = { task -> taskViewModel.completeTask(task) },
+            onPostponeClick = { task -> taskViewModel.postponeTask(task) },
+            onDeleteClick = { task -> taskViewModel.deleteTask(task) }
         )
         binding.recyclerView.apply {
             adapter = this@DateTasksDialogFragment.adapter

--- a/app/src/main/java/com/taskmaster/ui/fragments/StatisticsFragment.kt
+++ b/app/src/main/java/com/taskmaster/ui/fragments/StatisticsFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import com.taskmaster.R
 import com.taskmaster.databinding.FragmentStatisticsBinding
 import com.taskmaster.ui.viewmodel.TaskViewModel
 import com.taskmaster.ui.viewmodel.SphereViewModel

--- a/app/src/main/java/com/taskmaster/ui/fragments/TodayFragment.kt
+++ b/app/src/main/java/com/taskmaster/ui/fragments/TodayFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import com.google.android.material.snackbar.Snackbar
 import com.taskmaster.databinding.FragmentTodayBinding
 import com.taskmaster.ui.adapter.TaskAdapter

--- a/app/src/main/res/layout/dialog_tasks_by_date.xml
+++ b/app/src/main/res/layout/dialog_tasks_by_date.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
 
     android:layout_width="match_parent"
     android:layout_height="wrap_content">

--- a/app/src/main/res/layout/item_sphere_stat.xml
+++ b/app/src/main/res/layout/item_sphere_stat.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-
     xmlns:tools="http://schemas.android.com/tools"
-
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"


### PR DESCRIPTION
## Summary
- clean up complex task creation code to remove extraneous field reference
- pass task objects to adapter callbacks correctly
- import the app's R class in the statistics screen
- add coroutine launch import in TodayFragment

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a81e8d1848328b948193d45a62430