### PR TITLE
Fix layout namespace

### DIFF
--- a/app/src/main/res/layout/dialog_tasks_by_date.xml
+++ b/app/src/main/res/layout/dialog_tasks_by_date.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 


### PR DESCRIPTION
## Summary
- fix `dialog_tasks_by_date` layout missing `tools` namespace

## Testing
- `./gradlew assembleDebug` *(fails: unable to download Gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686a9fe519dc8328b0467d2ca5d30be6