### PR TITLE
Add missing tools namespaces

### DIFF
--- a/app/src/main/res/layout/fragment_date_tasks.xml
+++ b/app/src/main/res/layout/fragment_date_tasks.xml
@@ -2,12 +2,11 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="16dp"
+        android:layout_height="match_parent"
         tools:listitem="@layout/item_task" />
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_task_detail.xml
+++ b/app/src/main/res/layout/fragment_task_detail.xml
@@ -2,12 +2,11 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler_view"
-        android:layout_width="match_parent"
+    <TextView
+        android:id="@+id/text_task_detail"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="16dp"
-        tools:listitem="@layout/item_task" />
+        tools:text="Task Detail" />
 </FrameLayout>

--- a/app/src/main/res/layout/item_subtask.xml
+++ b/app/src/main/res/layout/item_subtask.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp"
+    tools:text="Subtask" />


### PR DESCRIPTION
## Summary
- add placeholder layouts with `tools` namespace for subtask, task detail, and tasks-by-date fragments

## Testing
- `./gradlew assembleDebug` *(fails: unable to download Gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686a9fe519dc8328b0467d2ca5d30be6